### PR TITLE
Further improved mobile header functionality

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
   <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,200' rel='stylesheet' type='text/css'>
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   <%= csrf_meta_tags %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 </head>
 <body>
 <%= render 'layouts/header' unless @disable_nav %>
@@ -16,6 +17,6 @@
 <%= yield %>
 <%= render 'layouts/footer' %>
 <%= debug(params) if Rails.env.development? %>
-<%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+
 </body>
 </html>


### PR DESCRIPTION
There was a problem selecting the username dropdown in the navbar, it took a lot of random clicking to get it to get to the dropdown and I guess it had to do with the location of the 'turbolinks' inclusion.  I moved it from the body to the header, and it seems to work fine now.

It also fixed the mobile version of the navigation.  Before, it wouldn't slide back up again if you hit the 'burger' icon, but that was fixed too!
